### PR TITLE
add link to privacy page in footers

### DIFF
--- a/_data/fij/footer.yml
+++ b/_data/fij/footer.yml
@@ -32,3 +32,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -44,3 +44,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)

--- a/_data/nu/footer.yml
+++ b/_data/nu/footer.yml
@@ -32,3 +32,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)

--- a/_data/sb/footer.yml
+++ b/_data/sb/footer.yml
@@ -32,3 +32,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)

--- a/_data/sm/footer.yml
+++ b/_data/sm/footer.yml
@@ -32,3 +32,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)

--- a/_data/tk/footer.yml
+++ b/_data/tk/footer.yml
@@ -32,3 +32,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)

--- a/_data/to/footer.yml
+++ b/_data/to/footer.yml
@@ -66,3 +66,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)

--- a/_data/tv/footer.yml
+++ b/_data/tv/footer.yml
@@ -32,3 +32,5 @@ columns:
   #  - text: link title 2
   #    href: http://example2.com
   #  connectIcons: true # optional - show social icons (defined in _config.yml)
+other: |
+  [Privacy policy](/privacy)


### PR DESCRIPTION
This PR provides a suggestion to link the privacy policy in the footer.

GBIF provide a privacy policy as a template for you, and you need to complete a few configuration parameters.
Please be aware that while we provide this template, and believe it to be reasonable, it is your responsibility - the service agreement (yet to be shared) will indicate this. You can overwrite the template similar to any other file in your portal.